### PR TITLE
Add Compose demo module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Compose Guide Demo
+
+This sample demonstrates a simple-to-advanced Jetpack Compose setup using Material3 components and navigation.
+
+## Modules
+- **SimpleScreen** shows a welcome message and navigation button.
+- **AdvancedScreen** demonstrates a basic animation using `AnimatedVisibility`.
+
+## Running
+Use Android Studio or Gradle to build the `app` module. The project uses Material 3 and Navigation Compose.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,50 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.composeguide'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.example.composeguide'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName '1.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.0'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    implementation 'androidx.activity:activity-compose:1.8.2'
+    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+    implementation 'androidx.navigation:navigation-compose:2.7.7'
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.composeguide">
+
+    <application
+        android:allowBackup="true"
+        android:label="Compose Guide"
+        android:theme="@style/Theme.ComposeGuide">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/composeguide/MainActivity.kt
+++ b/app/src/main/java/com/example/composeguide/MainActivity.kt
@@ -1,0 +1,43 @@
+package com.example.composeguide
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.animation.core.tween
+import androidx.compose.material3.Text
+import androidx.compose.ui.graphics.Color
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.composeguide.ui.AdvancedScreen
+import com.example.composeguide.ui.SimpleScreen
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ComposeGuideTheme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    AppNavigation()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun AppNavigation() {
+    val navController = rememberNavController()
+    NavHost(navController, startDestination = "simple") {
+        composable("simple") {
+            SimpleScreen(onNext = { navController.navigate("advanced") })
+        }
+        composable("advanced") {
+            AdvancedScreen(onBack = { navController.popBackStack() })
+        }
+    }
+}

--- a/app/src/main/java/com/example/composeguide/Theme.kt
+++ b/app/src/main/java/com/example/composeguide/Theme.kt
@@ -1,0 +1,18 @@
+package com.example.composeguide
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+private val LightColors = lightColorScheme()
+private val DarkColors = darkColorScheme()
+
+@Composable
+fun ComposeGuideTheme(
+    darkTheme: Boolean = false,
+    content: @Composable () -> Unit
+) {
+    val colors = if (darkTheme) DarkColors else LightColors
+    MaterialTheme(colorScheme = colors, content = content)
+}

--- a/app/src/main/java/com/example/composeguide/ui/AdvancedScreen.kt
+++ b/app/src/main/java/com/example/composeguide/ui/AdvancedScreen.kt
@@ -1,0 +1,40 @@
+package com.example.composeguide.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun AdvancedScreen(onBack: () -> Unit) {
+    val visible = remember { mutableStateOf(true) }
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        AnimatedVisibility(
+            visible = visible.value,
+            enter = fadeIn(animationSpec = tween(500)),
+            exit = fadeOut(animationSpec = tween(500))
+        ) {
+            Text(text = "Fancy animation!")
+        }
+        Button(onClick = { visible.value = !visible.value }) {
+            Text("Toggle")
+        }
+        Button(onClick = onBack) {
+            Text("Back")
+        }
+    }
+}

--- a/app/src/main/java/com/example/composeguide/ui/SimpleScreen.kt
+++ b/app/src/main/java/com/example/composeguide/ui/SimpleScreen.kt
@@ -1,0 +1,24 @@
+package com.example.composeguide.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SimpleScreen(onNext: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Welcome to Compose Guide")
+        Button(onClick = onNext) {
+            Text("Show Advanced")
+        }
+    }
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<resources>
+    <color name="purple_80">#D0BCFF</color>
+    <color name="purple_40">#6650a4</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Compose Guide</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.ComposeGuide" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/purple_40</item>
+        <item name="colorPrimaryContainer">@color/purple_80</item>
+    </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'com.android.application' version '8.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,9 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "ComposeGuide"
+include(":app")


### PR DESCRIPTION
## Summary
- introduce a simple Jetpack Compose demo with Material3 and navigation
- provide simple and advanced screens demonstrating animation
- include Gradle setup and theme configuration

## Testing
- `gradle tasks --console=plain --no-daemon` *(fails: Plugin com.android.application not found)*