### PR TITLE
Add Android CI workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,29 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'gradle'
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v3
+    - name: Build
+      run: |
+        if [ -f ./gradlew ]; then
+          ./gradlew assembleRelease
+        else
+          gradle assembleRelease
+        fi
+

--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ This sample demonstrates a simple-to-advanced Jetpack Compose setup using Materi
 
 ## Running
 Use Android Studio or Gradle to build the `app` module. The project uses Material 3 and Navigation Compose.
+
+## Continuous Integration
+A GitHub Actions workflow builds the project on every push or pull request. The workflow uses the latest Ubuntu runner with JDK 17 and installs the Android SDK before running `./gradlew assembleRelease`. This setup is free to use on public repositories.


### PR DESCRIPTION
## Summary
- configure GitHub Actions to build the Android app
- document the CI pipeline in the README

## Testing
- `gradle build` *(fails: Plugin not found due to no network access)*