### PR TITLE
Update Compose BoM and Material3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
@@ -41,9 +41,9 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
     implementation 'androidx.activity:activity-compose:1.8.2'
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     implementation 'androidx.navigation:navigation-compose:2.8.0'

--- a/module1/build.gradle
+++ b/module1/build.gradle
@@ -22,12 +22,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
 }

--- a/module10/build.gradle
+++ b/module10/build.gradle
@@ -22,12 +22,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
 }

--- a/module2/build.gradle
+++ b/module2/build.gradle
@@ -22,12 +22,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
 }

--- a/module3/build.gradle
+++ b/module3/build.gradle
@@ -22,12 +22,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
 }

--- a/module4/build.gradle
+++ b/module4/build.gradle
@@ -22,12 +22,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
 }

--- a/module5/build.gradle
+++ b/module5/build.gradle
@@ -22,12 +22,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
 }

--- a/module6/build.gradle
+++ b/module6/build.gradle
@@ -22,12 +22,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
 }

--- a/module7/build.gradle
+++ b/module7/build.gradle
@@ -22,12 +22,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
 }

--- a/module8/build.gradle
+++ b/module8/build.gradle
@@ -22,12 +22,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
 }

--- a/module9/build.gradle
+++ b/module9/build.gradle
@@ -22,12 +22,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2025.05.00')
     implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.compose.material3:material3:1.3.2'
 }


### PR DESCRIPTION
## Summary
- update Compose compiler extension to 1.5.15
- use Compose BoM 2025.05.00
- depend on Material3 1.3.2

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application'] was not found)*